### PR TITLE
Added parameters to calls to super() in forms.py to be Python 2.7 compatible

### DIFF
--- a/array_field_select/forms.py
+++ b/array_field_select/forms.py
@@ -12,11 +12,11 @@ class SelectArrayField(Field):
         self.base_field.choices = self.base_field.choices[1:]
         self.max_length = max_length
         self.widget = self.base_field.widget
-        super().__init__(**kwargs)
+        super(SelectArrayField, self).__init__(**kwargs)
 
     def clean(self, value):
         value = self.base_field.clean(value)
-        value = super().clean(value)
+        value = super(SelectArrayField, self).clean(value)
         return self.base_field.clean(value)
 
     def validate(self, value):


### PR DESCRIPTION
In Python 2.7, `super` requires the name of the class and an instance of the class (`self`) as parameters.

This patch fixes the following error:

```python
TypeError: Error when calling the metaclass bases
```